### PR TITLE
add ability to sort columns with a custom sort function

### DIFF
--- a/lib/tabula.js
+++ b/lib/tabula.js
@@ -60,7 +60,7 @@ function sortArrayOfObjects(items, fields, options) {
             }
             assert.object(obj, 'obj');
             assert.string(obj.field, 'obj.field');
-            assert.optionalFunc(obj.comparator, 'obj.comparator');
+            assert.optionalFunc(obj.keyFunc, 'obj.keyFunc');
 
             var field = obj.field;
             var invert = false;
@@ -82,16 +82,19 @@ function sortArrayOfObjects(items, fields, options) {
                 a_field = a[field];
                 b_field = b[field];
             }
-            var a_cmp = Number(a_field);
-            var b_cmp = Number(b_field);
-            if (isNaN(a_cmp) || isNaN(b_cmp)) {
-                a_cmp = a_field;
-                b_cmp = b_field;
-            }
 
-            // Use user-supplied comparator function if supplied
-            if (typeof (obj.comparator) === 'function') {
-                return obj.comparator(a_cmp, b_cmp);
+            var a_cmp;
+            var b_cmp;
+            if (obj.keyFunc) {
+                a_cmp = obj.keyFunc(a_field);
+                b_cmp = obj.keyFunc(b_field);
+            } else {
+                b_cmp = Number(b_field);
+                a_cmp = Number(a_field);
+                if (isNaN(a_cmp) || isNaN(b_cmp)) {
+                    a_cmp = a_field;
+                    b_cmp = b_field;
+                }
             }
 
             // Comparing < or > to `undefined` with any value always

--- a/lib/tabula.js
+++ b/lib/tabula.js
@@ -52,7 +52,17 @@ function sortArrayOfObjects(items, fields, options) {
 
     function cmp(a, b) {
         for (var i = 0; i < fields.length; i++) {
-            var field = fields[i];
+            var obj = fields[i];
+            if (typeof (obj) !== 'object') {
+                obj = {
+                    field: obj
+                };
+            }
+            assert.object(obj, 'obj');
+            assert.string(obj.field, 'obj.field');
+            assert.optionalFunc(obj.comparator, 'obj.comparator');
+
+            var field = obj.field;
             var invert = false;
             if (field[0] === '-') {
                 invert = true;
@@ -78,6 +88,12 @@ function sortArrayOfObjects(items, fields, options) {
                 a_cmp = a_field;
                 b_cmp = b_field;
             }
+
+            // Use user-supplied comparator function if supplied
+            if (typeof (obj.comparator) === 'function') {
+                return obj.comparator(a_cmp, b_cmp);
+            }
+
             // Comparing < or > to `undefined` with any value always
             // returns false.
             if (a_cmp === undefined && b_cmp === undefined) {
@@ -204,7 +220,7 @@ function tabulaFormat(items, options) {
     assert.optionalObject(options, 'options');
     options = options || {};
     assert.optionalBool(options.skipHeader, 'options.skipHeader');
-    assert.optionalArrayOfString(options.sort, 'options.sort');
+    assert.optionalArray(options.sort, 'options.sort');
     assert.optionalArrayOfString(options.validFields, 'options.validFields');
     assert.optionalBool(options.dottedLookup, 'options.dottedLookup');
     assert.optionalBool(options.noAnsi, 'options.noAnsi');

--- a/test/cases.test.js
+++ b/test/cases.test.js
@@ -42,7 +42,7 @@ var cases = caseFiles.map(function (caseFile) {
         expect: {
             stdout: (data[1] ? data[1].trim() + '\n' : '')
         },
-        options: (data[2] ? JSON.parse(data[2]) : undefined)
+        options: (data[2] ? eval(';(_=' + data[2] + ');') : undefined)
     };
 });
 debug('cases:', JSON.stringify(cases, null, 4));

--- a/test/cases/sort-func.case
+++ b/test/cases/sort-func.case
@@ -1,0 +1,21 @@
+[{"ip":"10.0.1.0"},{"ip":"10.0.1.1"},{"ip":"10.0.1.10"},{"ip":"10.0.1.2"}]
+
+IP
+10.0.1.0
+10.0.1.1
+10.0.1.2
+10.0.1.10
+
+{
+    "columns": ["ip"],
+    "sort": [
+        {
+            "field": "ip",
+	    "comparator": function reallyBadIpSort(a, b) {
+	        var last_a = parseInt(a.split('.')[3], 10);
+	        var last_b = parseInt(b.split('.')[3], 10);
+		return (last_a < last_b) ? -1 : 1;
+	    }
+	}
+    ]
+}

--- a/test/cases/sort-func.case
+++ b/test/cases/sort-func.case
@@ -11,11 +11,9 @@ IP
     "sort": [
         {
             "field": "ip",
-	    "comparator": function reallyBadIpSort(a, b) {
-	        var last_a = parseInt(a.split('.')[3], 10);
-	        var last_b = parseInt(b.split('.')[3], 10);
-		return (last_a < last_b) ? -1 : 1;
-	    }
-	}
+            "keyFunc": function reallyBadIp2Long(ip) {
+                return (parseInt(ip.split('.')[3], 10));
+            }
+        }
     ]
 }


### PR DESCRIPTION
This is needed by https://smartos.org/bugview/TRITON-24

With this change in place, the `sort` array may contain objects now that specify the field to sort, and also the `comparator` function to use when sorting.  For example:

``` js
{
  "columns": ["foo", "bar"],
  "sort": [
    "bar",
    {
      "field": "foo",
      "comparator": function (a, b) { return (a < b) ? 1 : -1; }
    }
  ]
}
````

If an element in the `sort` array is a string, it will use the default comparator function (the current behavior in master).

An unfortunate change to make the test case work was to use `eval` instead of `JSON.parse` on the options section of the test case to ensure the function was parsed properly.  Since the test cases are controlled by the repo I figure this shouldn't be too much of a security concern.

-edit-

Tests passing

```
dave.eddy - joyent-laptop darwin ~/dev/node-tabula (git:dave-sort-func) $ npm test

> tabula@1.9.0 test /Users/dave.eddy/dev/node-tabula
> make test

./node_modules/.bin/nodeunit test/*.test.js

basics.test.js
✔ exports

cases.test.js
✔ case: align-right
✔ case: array-cell
✔ case: dotted-lookup-sort
✔ case: dotted-lookup
✔ case: empty-table-no-columns
✔ case: empty-table-skip-header
✔ case: empty-table-with-columns
✔ case: maxwidth
✔ case: no-columns-option
✔ case: obj-columns
✔ case: object-cell
✔ case: simple
✔ case: skip-header
✔ case: sort-func
✔ case: sort-simple
✔ case: undefined-value-dotted-lookup
✔ case: undefined-value
✔ case: width
✔ manual case: function-cell

OK: 21 assertions (55ms)
```